### PR TITLE
python script support

### DIFF
--- a/fmask/cmdline/sentinel2Stacked.py
+++ b/fmask/cmdline/sentinel2Stacked.py
@@ -114,7 +114,7 @@ def getCmdargs(argv=None):
     params.add_argument("--parallaxtest", default=False, action="store_true",
         help="Turn on the parallax displacement test from Frantz (2018) (default will not use this test)")
 
-    cmdargs = parser.parse_args()
+    cmdargs = parser.parse_args(argv)
 
     # Do some sanity checks on what was given
     safeDirGiven = (cmdargs.safedir is not None)

--- a/fmask/cmdline/sentinel2Stacked.py
+++ b/fmask/cmdline/sentinel2Stacked.py
@@ -54,7 +54,7 @@ if GDALWARPCMD is None:
     raise fmaskerrors.FmaskInstallationError(msg)
 
 
-def getCmdargs():
+def getCmdargs(argv=None):
     """
     Get command line arguments
     """
@@ -282,11 +282,11 @@ def findGranuleXml(granuleDir):
     return xmlfile
 
 
-def mainRoutine():
+def mainRoutine(argv=None):
     """
     Main routine that calls fmask
     """
-    cmdargs = getCmdargs()
+    cmdargs = getCmdargs(argv)
     tempStack = False
     if cmdargs.safedir is not None or cmdargs.granuledir is not None:
         tempStack = True

--- a/fmask/cmdline/sentinel2Stacked.py
+++ b/fmask/cmdline/sentinel2Stacked.py
@@ -59,8 +59,8 @@ def getCmdargs(argv=None):
     Get command line arguments
     
     If argv is given, it should be a list of pairs of parameter and arguments like in command line.
-    See getCmdArgs(['-h']) for details on available parameters.
-    Example: getCmdArgs(['--safedir', '<.SAFE directory>', '-o', '<output file>'])
+    See getCmdargs(['-h']) for details on available parameters.
+    Example: getCmdargs(['--safedir', '<.SAFE directory>', '-o', '<output file>'])
     
     If argv is None or not given, command line sys.args are used, see argparse.parse_args.
     """

--- a/fmask/cmdline/sentinel2Stacked.py
+++ b/fmask/cmdline/sentinel2Stacked.py
@@ -57,6 +57,12 @@ if GDALWARPCMD is None:
 def getCmdargs(argv=None):
     """
     Get command line arguments
+    
+    If argv is given, it should be a list of pairs of parameter and arguments like in command line.
+    See getCmdArgs(['-h']) for details on available parameters.
+    Example: getCmdArgs(['--safedir', '<.SAFE directory>', '-o', '<output file>'])
+    
+    If argv is None or not given, command line sys.args are used, see argparse.parse_args.
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("--safedir", help=("Name of .SAFE directory, as unzipped from " +
@@ -285,6 +291,12 @@ def findGranuleXml(granuleDir):
 def mainRoutine(argv=None):
     """
     Main routine that calls fmask
+    
+    If argv is given, it should be a list of pairs of parameter and arguments like in command line.
+    See mainRoutine(['-h']) for details on available parameters.
+    Example: mainRoutine(['--safedir', '<.SAFE directory>', '-o', '<output file>'])
+    
+    If argv is None or not given, command line sys.args are used, see argparse.parse_args.
     """
     cmdargs = getCmdargs(argv)
     tempStack = False


### PR DESCRIPTION
Current version is made for command line only, i.e. command line arguments are taken from sys.argv.
I propose to add an argv argument to mainRoutine so that it can be called directly from a python session with a list of arguments.
Not as clean as a list of named arguments, but an easy way to extend support to python scripting without moodifying to much your code.
Example:
```python
from fmask.cmdline import sentinel2Stacked
sentinel2Stacked.mainRoutine(['--safedir', '<directory>', '-o', '<output directory>', '--parallaxtest'])
```
I have done it with sentinel2Stacked, but it could be easily extended to others mainRoutines.
