### PR TITLE
Ignore INSPIRE.xml when searching for metadata file in old-format zips

### DIFF
--- a/fmask/cmdline/sentinel2Stacked.py
+++ b/fmask/cmdline/sentinel2Stacked.py
@@ -313,7 +313,7 @@ def readTopLevelMeta(cmdargs):
         # named for the date of acquisition. It should be the only 
         # .xml file in that directory. 
         topLevelXML = None
-        xmlList = glob.glob(os.path.join(safeDir, "*.xml"))
+        xmlList = [f for f in glob.glob(os.path.join(safeDir, "*.xml")) if "INSPIRE.xml" not in f]
         if len(xmlList) == 1:
             topLevelXML = xmlList[0]
     if topLevelXML is None:


### PR DESCRIPTION
The recently added code for finding the metadata xml in old format files got tripped up on the INSPIRE.xml file being present in the top directory. 

I think these files are there by default in at least some if not all Sentinel-2 sources, so it's worth accounting for.

Thank you for your great work!