### PR TITLE
convert from bool to uint8 before writing output

### DIFF
--- a/fmask/fmask.py
+++ b/fmask/fmask.py
@@ -769,6 +769,8 @@ def cloudFinalPass(info, inputs, outputs, otherargs):
     # they set a pixel to cloud if 5 or more of its 3x3 neighbours is cloud. 
     # This little incantation will do exactly the same. 
     bufferedCloudmask = (uniform_filter(cloudmask * 2.0, size=3) >= 1.0)
+    # convert to int so we can write it with GDAL
+    bufferedCloudmask = bufferedCloudmask.astype(numpy.uint8)
 
     bufferedCloudmask[nullmask] = 0
     


### PR DESCRIPTION
Older GDAL versions appeared to convert `bool` arrays to `uint8` before writing. This no longer works happens and as a result the code reports an error as HFA does not support bools.

This fix just does the conversion to `uint8` before writing.