### PR TITLE
use entrypoints instead of .py scripts for the command line

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,3 +1,8 @@
+
+WARNING: To install python-fmask it is strongly  recommended to use the conda forge
+pre-built binaries. Only install from source if you absolutely must.
+
+
 To install python-fmask from the source code bundle, use the following commands
 
 First unpack the bundle. For the tar.gz file, this would be 

--- a/bin/fmask_sentinel2Stacked.py
+++ b/bin/fmask_sentinel2Stacked.py
@@ -17,6 +17,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from fmask.cmdline import sentinel2Stacked
+import warnings
+warnings.warn("Future versions of fmask may remove the .py extension from this script name", DeprecationWarning)
 
 if __name__ == '__main__':
     sentinel2Stacked.mainRoutine()

--- a/bin/fmask_sentinel2makeAnglesImage.py
+++ b/bin/fmask_sentinel2makeAnglesImage.py
@@ -17,6 +17,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from fmask.cmdline import sentinel2makeAnglesImage
+import warnings
+warnings.warn("Future versions of fmask may remove the .py extension from this script name", DeprecationWarning)
 
 if __name__ == "__main__":
     sentinel2makeAnglesImage.mainRoutine()

--- a/bin/fmask_usgsLandsatMakeAnglesImage.py
+++ b/bin/fmask_usgsLandsatMakeAnglesImage.py
@@ -17,6 +17,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from fmask.cmdline import usgsLandsatMakeAnglesImage
+import warnings
+warnings.warn("Future versions of fmask may remove the .py extension from this script name", DeprecationWarning)
 
 if __name__ == "__main__":
     usgsLandsatMakeAnglesImage.mainRoutine()

--- a/bin/fmask_usgsLandsatSaturationMask.py
+++ b/bin/fmask_usgsLandsatSaturationMask.py
@@ -17,6 +17,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from fmask.cmdline import usgsLandsatSaturationMask
+import warnings
+warnings.warn("Future versions of fmask may remove the .py extension from this script name", DeprecationWarning)
 
 if __name__ == '__main__':
     usgsLandsatSaturationMask.mainRoutine()

--- a/bin/fmask_usgsLandsatStacked.py
+++ b/bin/fmask_usgsLandsatStacked.py
@@ -17,7 +17,9 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from fmask.cmdline import usgsLandsatStacked
-    
+import warnings
+warnings.warn("Future versions of fmask may remove the .py extension from this script name", DeprecationWarning)
+
 if __name__ == '__main__':
     usgsLandsatStacked.mainRoutine()
 

--- a/bin/fmask_usgsLandsatTOA.py
+++ b/bin/fmask_usgsLandsatTOA.py
@@ -17,6 +17,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from fmask.cmdline import usgsLandsatTOA
+import warnings
+warnings.warn("Future versions of fmask may remove the .py extension from this script name", DeprecationWarning)
     
 if __name__ == '__main__':
     usgsLandsatTOA.mainRoutine()

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -102,7 +102,7 @@ The command line scripts supplied can process an untarred USGS Landsat scene.
 Here is an example of how to do this. This command will take a given scene directory, 
 find the right images, and create an output file called cloud.img::
 
-    fmask_usgsLandsatStacked.py -o cloud.img --scenedir LC08_L1TP_150033_20150413_20170410_01_T1
+    fmask_usgsLandsatStacked -o cloud.img --scenedir LC08_L1TP_150033_20150413_20170410_01_T1
 
 If the thermal band is empty (for Landsat-8 with the SSM anomaly, after 2015-11-01) then it
 is ignored gracefully.
@@ -125,13 +125,13 @@ slower, and is unlikely to be any more accurate.
 This command will take a given .SAFE directory, find the right images, and create an
 output file called cloud.img::
 
-    fmask_sentinel2Stacked.py -o cloud.img --safedir S2B_MSIL1C_20180918T235239_N0206_R130_T56JNQ_20180919T011001.SAFE
+    fmask_sentinel2Stacked -o cloud.img --safedir S2B_MSIL1C_20180918T235239_N0206_R130_T56JNQ_20180919T011001.SAFE
 
 When working with the old ESA zipfile format, which packed multiple tiles into a single SAFE-format
 zipfile, this approach will not work, as it won't know which tile to process. So, instead, use
 the option to specify the granule directory, as follows::
 
-    fmask_sentinel2Stacked.py -o cloud.img --granuledir S2A_OPER_PRD_MSIL1C_PDMC_20160111T072442_R030_V20160111T000425_20160111T000425.SAFE/GRANULE/S2A_OPER_MSI_L1C_TL_SGS__20160111T051031_A002887_T56JNQ_N02.01
+    fmask_sentinel2Stacked -o cloud.img --granuledir S2A_OPER_PRD_MSIL1C_PDMC_20160111T072442_R030_V20160111T000425_20160111T000425.SAFE/GRANULE/S2A_OPER_MSI_L1C_TL_SGS__20160111T051031_A002887_T56JNQ_N02.01
 
 This would also work on a new-format directory, but specifying the top .SAFE directory is easier. 
 
@@ -155,13 +155,11 @@ Get the source as a bundle from `GitHub <https://github.com/ubarsc/python-fmask/
 Release notes for each version can be read in :doc:`releasenotes`. To install from source,
 read the INSTALL.txt file included inside the source bundle.
 
-Pre-built binary `Conda <http://conda.pydata.org/miniconda.html#miniconda>`_ packages are available
+Pre-built binary `Conda <https://github.com/conda-forge/miniforge>`_ packages are available
 under the 'conda-forge' channel. Once you have installed
-`Conda <http://conda.pydata.org/miniconda.html#miniconda>`_, run the following commands on the
+`Conda <https://github.com/conda-forge/miniforge>`_, run the following commands on the
 command line to install python-fmask: ::
 
-    conda config --add channels conda-forge
-    conda config --set channel_priority strict
     conda create -n myenv python-fmask
     conda activate myenv
 

--- a/fmask/config.py
+++ b/fmask/config.py
@@ -28,6 +28,8 @@ from osgeo import gdal
 from rios import applier
 from . import fmaskerrors
 
+gdal.UseExceptions()
+
 FMASK_LANDSAT47 = 0
 "Landsat 4 to 7"
 FMASK_LANDSAT8 = 1
@@ -436,7 +438,7 @@ class FmaskFilenames(object):
         This should have numbers which are reflectance * 1000
         
         Use the :func:`fmask.landsatTOA.makeTOAReflectance` function to create
-        this file from raw Landsat radiance (or the fmask_usgsLandsatTOA.py
+        this file from raw Landsat radiance (or the fmask_usgsLandsatTOA
         command line program supplied with fmask).
         
         It is assumed that any values that are nulls in the original radiance
@@ -686,7 +688,7 @@ class AnglesFileInfo(AnglesInfo):
         self.viewZenithData = None
         self.viewAzimuthData = None
         
-        # This default value matches the file produced by fmask_usgsLandsatMakeAnglesImage.py
+        # This default value matches the file produced by fmask_usgsLandsatMakeAnglesImage
         self.scaleToRadians = 0.01
     
     @staticmethod

--- a/fmask/fmask.py
+++ b/fmask/fmask.py
@@ -71,6 +71,7 @@ from . import fmaskerrors
 from . import zerocheck
 
 numpy.seterr(all='raise')
+gdal.UseExceptions()
 
 # Bands in the saturation mask, if supplied
 SATURATION_BLUE = 0

--- a/fmask/landsatTOA.py
+++ b/fmask/landsatTOA.py
@@ -26,6 +26,8 @@ from osgeo import gdal
 from rios import applier, cuiprogress, fileinfo
 from . import config
 
+gdal.UseExceptions()
+
 # Derived by Pete Bunting from 6S
 LANDSAT8_ESUN = [1876.61, 1970.03, 1848.9, 1571.3, 967.66, 245.73, 82.03, 361.72]
 # From Chander, G., Markham, B.L., Helder, D.L. (2008)

--- a/fmask/landsatangles.py
+++ b/fmask/landsatangles.py
@@ -68,6 +68,8 @@ from osgeo import osr
 from rios import applier
 from rios import fileinfo
 
+osr.UseExceptions()
+
 
 def findImgCorners(img, imgInfo):
     """

--- a/fmask/sen2meta.py
+++ b/fmask/sen2meta.py
@@ -31,6 +31,8 @@ from osgeo import osr
 
 from . import fmaskerrors
 
+osr.UseExceptions()
+
 
 class Sen2TileMeta(object):
     """

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,15 @@ setup(name='python-fmask',
     author='Neil Flood',
     author_email='n.flood@uq.edu.au',
     scripts=scriptList,
+    entry_points={
+        'console_scripts': [
+            'fmask_sentinel2makeAnglesImage = fmask.cmdline.sentinel2makeAnglesImage:mainRoutine',
+            'fmask_sentinel2Stacked = fmask.cmdline.sentinel2Stacked:mainRoutine',
+            'fmask_usgsLandsatMakeAnglesImage = fmask.cmdline.usgsLandsatMakeAnglesImage:mainRoutine',
+            'fmask_usgsLandsatSaturationMask = fmask.cmdline.usgsLandsatSaturationMask:mainRoutine',
+            'fmask_usgsLandsatStacked = fmask.cmdline.usgsLandsatStacked:mainRoutine',
+            'fmask_usgsLandsatTOA = fmask.cmdline.usgsLandsatTOA:mainRoutine'
+        ]},
     packages=['fmask', 'fmask/cmdline'],
     ext_package='fmask',
     ext_modules=extensionsList,


### PR DESCRIPTION
.py scripts cause problems on the Windows command line. This was worked around to some degree by conda creating `.py.exe` entrypoints. However `pip install` refuses to do this and will only create `.exe` entrypoints (no .py). 

So this change will mainly benefit Windows users. However all examples of package entry points I can find don't have the .py so this will make usage more 'standard'. 

Calling the old .py scripts will now emit a warning. 

Also taken the opportunity to call `UseExceptions()` to quieten the warnings with latest GDAL. And update the conda links. Plus add an extra note in INSTALL.txt about conda in case this is all people look at.

@neilflood we must do a release very shortly after merging this as the documentation will not match the existing release command line names (removed .py).