### PR TITLE
Fix neighbour lookup to use correct 4-connectivity in fillminima.c

### DIFF
--- a/c_src/fillminima.c
+++ b/c_src/fillminima.c
@@ -182,24 +182,23 @@ static PQel *PQ_first(PixelQueue *pixQ, int h) {
     }
     return current;
 }
+
+static int di[4] = { 0, 0, -1, 1 };
+static int dj[4] = { -1, 1, 0, 0 };
     
 /* Return a list of neighbouring pixels to given pixel p.  */
 static PQel *neighbours(PQel *p, int nRows, int nCols) {
-    int ii, jj, i, j;
+    int n, i, j;
     PQel *pl, *pNew;
         
     pl = NULL;
-    for (ii=-1; ii<=1; ii++) {
-        for (jj=-1; jj<=1; jj++) {
-            if ((ii != 0) && (jj != 0)) {
-                i = p->i + ii;
-                j = p->j + jj;
-                if ((i >= 0) && (i < nRows) && (j >= 0) && (j < nCols)) {
-                    pNew = newPix(i, j);
-                    pNew->next = pl;
-                    pl = pNew;
-                }
-            }
+    for (n=0; n<4; n++) {
+        i = p->i + di[n];
+        j = p->j + dj[n];
+        if ((i >= 0) && (i < nRows) && (j >= 0) && (j < nCols)) {
+            pNew = newPix(i, j);
+            pNew->next = pl;
+            pl = pNew;
         }
     }
     return pl;


### PR DESCRIPTION
The previous implementation incorrectly added only diagonal neighbours to the queue, ignoring directly adjacent pixels (up, down, left, right). This could lead to checkerboard-like artifacts. The fix replaces the nested loop with a simple 4-directional lookup using static offset arrays.

In the screenshot you can see the checkboard-like artifact. Sometimes they can be a couple of DN's in a sink, which I believe depends on the starting element in the queue.

![image](https://github.com/user-attachments/assets/78386f27-53d7-48a0-84fb-68705747440b)

Full disclosure: I only tested this in my C++ Implementation because i'am currently not able to run python-fmask on my machine. 